### PR TITLE
Adjust stats and modelhandling for translation of data

### DIFF
--- a/StatTrackerGlobal.App/ViewModels/SetOverviewViewModel.cs
+++ b/StatTrackerGlobal.App/ViewModels/SetOverviewViewModel.cs
@@ -27,8 +27,7 @@ namespace StatTrackerGlobal.App.ViewModels
                                          int Attempts,
                                          int Errors,
                                          double KillPercentage,
-                                         double ErrorPercentage,
-                                         double KillErrorRatio);
+                                         double ErrorPercentage);
         public record SetOverviewBlocks(int KillBlocks,
                                         int Touches,
                                         int BlockErrors,

--- a/StatTrackerGlobal.Shared/DomainStatWrapper.cs
+++ b/StatTrackerGlobal.Shared/DomainStatWrapper.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace StatTrackerGlobal.Domain
 {
-    public class DomainStatWrapper
+    public record DomainStatWrapper
     {
         public Set StatSet { get; set; } = new();
 

--- a/StatTrackerGlobal.Shared/Stats/AttackingStats.cs
+++ b/StatTrackerGlobal.Shared/Stats/AttackingStats.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace StatTrackerGlobal.Domain.Stats
 {
-    public class AttackingStats
+    public record AttackingStats
     {
         public int Kills { get; set; }
         public int Attempts { get; set; }

--- a/StatTrackerGlobal.Shared/Stats/BlockingStats.cs
+++ b/StatTrackerGlobal.Shared/Stats/BlockingStats.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace StatTrackerGlobal.Domain.Stats
 {
-    public class BlockingStats
+    public record BlockingStats
     {
         public int KillBlocks { get; set; }
         public int Touches { get; set; }

--- a/StatTrackerGlobal.Shared/Stats/PassingStats.cs
+++ b/StatTrackerGlobal.Shared/Stats/PassingStats.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace StatTrackerGlobal.Domain.Stats
 {
-    public class PassingStats
+    public record PassingStats
     {
         public int Digs { get; set; }
         public int BallTouches { get; set; }

--- a/StatTrackerGlobal.Shared/Stats/ServeRecieveStats.cs
+++ b/StatTrackerGlobal.Shared/Stats/ServeRecieveStats.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace StatTrackerGlobal.Domain.Stats
 {
-    public class ServeRecieveStats
+    public record ServeRecieveStats
     {
         public int ThreePointPasses { get; set; }
         public int TwoPointPasses { get; set; }

--- a/StatTrackerGlobal.Shared/Stats/ServingStats.cs
+++ b/StatTrackerGlobal.Shared/Stats/ServingStats.cs
@@ -6,10 +6,11 @@ using System.Threading.Tasks;
 
 namespace StatTrackerGlobal.Domain.Stats
 {
-    public class ServingStats
+    public record ServingStats
     {
         public int Aces { get; set; }
         public int ServesMade { get; set; }
+        public int ServesMissed { get; set; }
         public int TotalServes { get; set; }
         public double ServePercentages { get; set; }
     }


### PR DESCRIPTION
Adjusted the way stats are represented in data. Each domain player now holds a list of sets and their performance for that set. This makes translation easier from domain to viewmodels, but can become repetitive and not graceful for domain and data model interaction