### PR TITLE
set deletion bug fix

### DIFF
--- a/StatTrackerGlobal.App/ApplicationService.cs
+++ b/StatTrackerGlobal.App/ApplicationService.cs
@@ -61,6 +61,7 @@ namespace StatTrackerGlobal.App
         }
         public MockViewState EditUpdatePlayerStatAction(SetOverviewPlayer playerToUpdate, SetOverviewViewModel currentSet)
         {
+            //alter this branch
             Predicate<VolleyballPlayer> playerExists = p => (p.FirstName + p.LastName == playerToUpdate.FirstName + playerToUpdate.LastName);
             VolleyballPlayer? domainPlayerToUpdate = DomainWrapper.Players.Find(playerExists);
             Predicate<DomainStatWrapper> statWrapperExists = s => (s.StatSet.Date == currentSet.Date) && (s.StatSet.Order == DomainWrapper.CurrentSet.Order);


### PR DESCRIPTION
Repro:
When exiting a set then attempting to delete a set, the set order gets reset to 0, making it impossible to fully delete the set